### PR TITLE
Customize commit messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 coverage
 lib
 node_modules
+.idea/

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Request](https://user-images.githubusercontent.com/316923/93274006-8922ef80-f7b9
   - [`paths-ignore`](#paths-ignore)
   - [`set-distribution-checksum`](#set-distribution-checksum)
   - [`release-channel`](#release-channel)
+  - [`commit-message-template`](#commit-message-template)
 - [Examples](#examples)
   - [Scheduling action execution](#scheduling-action-execution)
   - [Targeting a custom branch](#targeting-a-custom-branch)
@@ -406,6 +407,25 @@ For example:
 ```yaml
 with:
   release-channel: release-candidate
+```
+
+### `commit-message-template`
+
+| Name | Description | Required | Default |
+| --- | --- | --- | --- |
+| `commit-message-template` | The template to use for the commit message created by this action | No | `Update Gradle Wrapper from %sourceVersion% to %targetVersion%` |
+
+This input is used for the message of the commit created by this action. This allows for better integration into
+repositories which make use of commit message patterns like [Conventional Commits](https://www.conventionalcommits.org/).
+
+`%sourceVersion%` and `%targetVersion%` will be replaced by the current/old and the new version of the Gradle Wrapper
+respectively.
+
+For example:
+
+```yaml
+with:
+  commit-message-template: 'chore(deps): Bump Gradle Wrapper from %sourceVersion% to %targetVersion%'
 ```
 
 ## Examples

--- a/action.yml
+++ b/action.yml
@@ -45,6 +45,10 @@ inputs:
     description: 'Gradle release channel to be used (either `stable` or `release-candidate`).'
     required: false
     default: stable
+  commit-message-template:
+    description: 'Template used for commit message and PR title'
+    required: false
+    default: 'Update Gradle Wrapper from %sourceVersion% to %targetVersion%'
 
 runs:
   using: 'node16'

--- a/src/git/git-commit.ts
+++ b/src/git/git-commit.ts
@@ -14,13 +14,7 @@
 
 import * as git from './git-cmds';
 
-export async function commit(
-  files: string[],
-  targetVersion: string,
-  sourceVersion: string
-) {
+export async function commit(files: string[], commitMessage: string) {
   await git.add(files);
-  await git.commit(
-    `Update Gradle Wrapper from ${sourceVersion} to ${targetVersion}.`
-  );
+  await git.commit(commitMessage);
 }

--- a/src/inputs/index.ts
+++ b/src/inputs/index.ts
@@ -25,6 +25,7 @@ export interface Inputs {
   paths: string[];
   pathsIgnore: string[];
   releaseChannel: string;
+  commitMessageTemplate: string;
 }
 
 export function getInputs(): Inputs {
@@ -44,6 +45,7 @@ class ActionInputs implements Inputs {
   paths: string[];
   pathsIgnore: string[];
   releaseChannel: string;
+  commitMessageTemplate: string;
 
   constructor() {
     this.repoToken = core.getInput('repo-token', {required: false});
@@ -99,6 +101,15 @@ class ActionInputs implements Inputs {
     }
     if (!acceptedReleaseChannels.includes(this.releaseChannel)) {
       throw new Error('release-channel has unexpected value');
+    }
+
+    this.commitMessageTemplate = core
+      .getInput('commit-message-template', {required: false})
+      .trim();
+
+    if (!this.commitMessageTemplate) {
+      this.commitMessageTemplate =
+        'Update Gradle Wrapper from %sourceVersion% to %targetVersion%';
     }
   }
 }

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -17,6 +17,19 @@ import {Release} from './releases';
 const ISSUES_URL =
   'https://github.com/gradle-update/update-gradle-wrapper-action/issues';
 
+const TARGET_VERSION_PLACEHOLDER = '%targetVersion%';
+const SOURCE_VERSION_PLACEHOLDER = '%sourceVersion%';
+
+export function commitMessageText(
+  template: string,
+  source: string,
+  target: string
+): string {
+  return template
+    .replace(TARGET_VERSION_PLACEHOLDER, target)
+    .replace(SOURCE_VERSION_PLACEHOLDER, source);
+}
+
 export function pullRequestText(
   distTypes: Set<string>,
   targetRelease: Release,

--- a/src/tasks/main.ts
+++ b/src/tasks/main.ts
@@ -19,6 +19,7 @@ import * as gitAuth from '../git/git-auth';
 import * as store from '../store';
 
 import {commit} from '../git/git-commit';
+import {commitMessageText} from '../messages';
 import {createWrapperInfo} from '../wrapperInfo';
 import {createWrapperUpdater} from '../wrapperUpdater';
 import {findWrapperPropertiesFiles} from '../wrapper/find';
@@ -160,7 +161,13 @@ export class MainAction {
           core.endGroup();
 
           core.startGroup('Committing');
-          await commit(modifiedFiles, targetRelease.version, wrapper.version);
+
+          const commitMessage = commitMessageText(
+            this.inputs.commitMessageTemplate,
+            wrapper.version,
+            targetRelease.version
+          );
+          await commit(modifiedFiles, commitMessage);
           core.endGroup();
 
           commitDataList.push({

--- a/tests/github/gh-ops.test.ts
+++ b/tests/github/gh-ops.test.ts
@@ -35,7 +35,9 @@ const defaultMockInputs: Inputs = {
   setDistributionChecksum: true,
   paths: [],
   pathsIgnore: [],
-  releaseChannel: ''
+  releaseChannel: '',
+  commitMessageTemplate:
+    'Update Gradle Wrapper from %sourceVersion% to %targetVersion%'
 };
 
 const defaultMockGitHubApi: IGitHubApi = {

--- a/tests/inputs/inputs.test.ts
+++ b/tests/inputs/inputs.test.ts
@@ -15,6 +15,7 @@
 import * as core from '@actions/core';
 
 import {getInputs} from '../../src/inputs';
+
 jest.mock('@actions/core');
 
 describe('getInputs', () => {
@@ -44,6 +45,7 @@ describe('getInputs', () => {
     expect(getInputs()).toMatchInlineSnapshot(`
       ActionInputs {
         "baseBranch": "",
+        "commitMessageTemplate": "Update Gradle Wrapper from %sourceVersion% to %targetVersion%",
         "labels": Array [],
         "paths": Array [],
         "pathsIgnore": Array [],
@@ -186,6 +188,30 @@ describe('getInputs', () => {
 
         expect(getInputs().setDistributionChecksum).toEqual(expected);
       }
+    });
+  });
+
+  describe('commitMessageTemplate', () => {
+    it('defaults to "Update Gradle Wrapper from %sourceVersion% to %targetVersion%"', () => {
+      ymlInputs = {
+        'repo-token': 's3cr3t'
+      };
+
+      expect(getInputs().commitMessageTemplate).toStrictEqual(
+        'Update Gradle Wrapper from %sourceVersion% to %targetVersion%'
+      );
+    });
+
+    it('is set to the input string value', () => {
+      ymlInputs = {
+        'repo-token': 's3cr3t',
+        'commit-message-template':
+          'Change wrapper from %sourceVersion% to %targetVersion%'
+      };
+
+      expect(getInputs().commitMessageTemplate).toStrictEqual(
+        'Change wrapper from %sourceVersion% to %targetVersion%'
+      );
     });
   });
 

--- a/tests/messages.test.ts
+++ b/tests/messages.test.ts
@@ -12,8 +12,37 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {pullRequestText} from '../src/messages';
 import {Release} from '../src/releases';
+import {commitMessageText, pullRequestText} from '../src/messages';
+
+describe('commitMessageText', () => {
+  it('replaces %sourceVersion% with the source version parameter', () => {
+    const message = commitMessageText(
+      'Update from %sourceVersion%',
+      '1.0.0',
+      '1.0.1'
+    );
+    expect(message).toEqual('Update from 1.0.0');
+  });
+
+  it('replaces %targetVersion% with the source version parameter', () => {
+    const message = commitMessageText(
+      'Update to %targetVersion%',
+      '1.0.0',
+      '1.0.1'
+    );
+    expect(message).toEqual('Update to 1.0.1');
+  });
+
+  it('replaces both placeholders', () => {
+    const message = commitMessageText(
+      'Update from %sourceVersion% to %targetVersion%',
+      '1.0.0',
+      '1.0.1'
+    );
+    expect(message).toEqual('Update from 1.0.0 to 1.0.1');
+  });
+});
 
 describe('pullRequestText', () => {
   const distributionTypes = new Set(['all', 'bin']);

--- a/tests/tasks/main.test.ts
+++ b/tests/tasks/main.test.ts
@@ -42,7 +42,9 @@ const defaultMockInputs: Inputs = {
   setDistributionChecksum: true,
   paths: [],
   pathsIgnore: [],
-  releaseChannel: ''
+  releaseChannel: '',
+  commitMessageTemplate:
+    'Update Gradle Wrapper from %sourceVersion% to %targetVersion%'
 };
 
 const defaultMockGitHubApi: IGitHubApi = {
@@ -150,8 +152,7 @@ describe('run', () => {
         '/path/to/gradle/wrapper/gradle-wrapper.properties',
         '/path/to/gradle/wrapper/gradle-wrapper.jar'
       ],
-      '1.0.1',
-      '1.0.0'
+      'Update Gradle Wrapper from 1.0.0 to 1.0.1'
     );
 
     expect(git.push).toHaveBeenCalledWith('gradlew-update-1.0.1');


### PR DESCRIPTION
This change adds a new input to the action. It can be used to customize
the message of the commit created by this action.

This input is not required and has the default value `Update Gradle
Wrapper from %sourceVersion% to %targetVersion%`, where `%sourceVersion%`
will be replaced by the current/old version of the Gradle Wrapper and
`%targetVersion%` will be replaced by the new version of the Gradle
Wrapper.

The PR title and body remain unaffected by this change.

Implements https://github.com/gradle-update/update-gradle-wrapper-action/issues/246